### PR TITLE
add list of contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ If you see any issues in the specifications, or have any questions, please [open
 
 Please see the [license for this repository][8] to view the licenses for different parts of this project.
 
+## Other Contributors
+
+* [Andrea L. Berez-Kroeker](http://www2.hawaii.edu/~aberez/)
+* [Matthew Cecil](https://www.linkedin.com/in/matthew-cecil-071b3862/)
+* Venkat Patnala
+* [Kevin Schäfer](http://www.linguistics.ucsb.edu/people/kevin-schäfer)
+
 [1]: http://www.linguistics.ucsb.edu/people/john-w-du-bois
 [2]: https://semver.org
 [3]: https://github.com/digitallinguistics/DFT/releases

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     },
     {
       "name": "Andrea L. Berez-Kroeker"
+    },
+    {
+      "name": "Venkat Patnala"
     }
   ],
   "repository": {


### PR DESCRIPTION
These are intellectual contributors rather than code contributors, so they've just been added to an **Other Contributors** section of the readme, rather than in a separate CONTRIBUTORS.md file.

Closes #21